### PR TITLE
Fix wrong "install" command

### DIFF
--- a/packages/cli/src/create/add.ts
+++ b/packages/cli/src/create/add.ts
@@ -229,7 +229,7 @@ export async function addIndexer({
   console.log();
 
   consola.info(
-    `Before running the indexer, run ${cyan(`${options.packageManager} run install`)}${
+    `Before running the indexer, run ${cyan(`${options.packageManager} install`)}${
       language === "typescript"
         ? " & " + cyan(`${options.packageManager} run prepare`)
         : ""

--- a/packages/cli/src/create/add.ts
+++ b/packages/cli/src/create/add.ts
@@ -231,7 +231,7 @@ export async function addIndexer({
   consola.info(
     `Before running the indexer, run ${cyan(`${options.packageManager} install`)}${
       language === "typescript"
-        ? " & " + cyan(`${options.packageManager} run prepare`)
+        ? cyan(` && ${options.packageManager} run prepare`)
         : ""
     }`,
   );


### PR DESCRIPTION
Hi,
When we init a new apibara project with `apibara init` the CLI invite us to run the command `npm run install` but is must be `npm install`.
In addition, I copied and pasted the whole command proposed by CLI without paying too much attention that I need to run install and prepare command separately, and an unexpected behaviour because of the `&`.
I suggest clarifying things a little by using the `&&` operator, thus allowing you to copy/paste the entire command, chaining the install and prepare commands. 
Regards